### PR TITLE
Fix quick view endpoint and refresh cart

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -107,15 +107,33 @@ function clearCart() {
 }
 
 function updateCartDisplay() {
-    // Enhanced cart display update
-    const cartContainer = document.getElementById('cart-container');
+    // If the current page defines a loadCart() helper use it
+    if (typeof window.loadCart === 'function') {
+        window.loadCart();
+        return;
+    }
+
+    const cartContainer = document.getElementById('cart-items');
+    const cartData = cart || JSON.parse(localStorage.getItem('cart')) || [];
+
     if (cartContainer) {
-        // Update cart items with animations
-        cartContainer.style.opacity = '0.5';
-        setTimeout(() => {
-            // Update content here
-            cartContainer.style.opacity = '1';
-        }, 300);
+        if (cartData.length === 0) {
+            cartContainer.innerHTML =
+                '<p class="text-center text-muted">Tu carrito está vacío</p>';
+            return;
+        }
+
+        let html = '';
+        cartData.forEach(item => {
+            const total = item.price * item.quantity;
+            html += `<div class="d-flex align-items-center mb-2">
+                        <img src="${item.image}" alt="${item.name}" style="width:40px;height:40px;object-fit:cover" class="me-2 rounded">
+                        <div class="flex-grow-1">${item.name} x${item.quantity}</div>
+                        <small class="text-muted">$${total.toLocaleString()}</small>
+                    </div>`;
+        });
+
+        cartContainer.innerHTML = html;
     }
 }
 

--- a/quick_view.php
+++ b/quick_view.php
@@ -1,0 +1,43 @@
+<?php
+require_once 'config/config.php';
+require_once 'classes/Product.php';
+
+header('Content-Type: application/json');
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if (!$id) {
+    echo json_encode(['success' => false, 'message' => 'ID invalido']);
+    exit;
+}
+
+$productModel = new Product();
+$product = $productModel->getProductById($id);
+if (!$product) {
+    echo json_encode(['success' => false, 'message' => 'Producto no encontrado']);
+    exit;
+}
+
+$image = Product::getImagePath($product);
+$price = (float) ($product['price'] ?? 0);
+$discountPrice = isset($product['discount_price']) && $product['discount_price'] !== null
+    ? (float) $product['discount_price']
+    : null;
+$finalPrice = $discountPrice !== null ? $discountPrice : $price;
+$discountPercentage = $discountPrice !== null && $price > 0
+    ? round((1 - ($discountPrice / $price)) * 100)
+    : 0;
+
+$response = [
+    'success' => true,
+    'id' => $product['id'],
+    'name' => $product['name'],
+    'description' => $product['short_description'] ?: $product['description'],
+    'price' => $price,
+    'discount_price' => $discountPrice,
+    'final_price' => $finalPrice,
+    'discount_percentage' => $discountPercentage,
+    'image' => $image,
+];
+
+echo json_encode($response);
+


### PR DESCRIPTION
## Summary
- add missing `quick_view.php` for product data
- refresh cart UI when adding items

## Testing
- `USE_SQLITE=1 php test_system.php`

------
https://chatgpt.com/codex/tasks/task_b_687a975e9aa48333810307359863a2a9